### PR TITLE
Compress event submissions using gzip

### DIFF
--- a/.licensed.yaml
+++ b/.licensed.yaml
@@ -11,3 +11,7 @@ allowed:
   - cc0-1.0
   - isc
   - mpl-2.0
+
+reviewed:
+  npm:
+    - pako

--- a/package-lock.json
+++ b/package-lock.json
@@ -423,6 +423,12 @@
       "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
       "dev": true
     },
+    "@types/pako": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-1.0.1.tgz",
+      "integrity": "sha512-GdZbRSJ3Cv5fiwT6I0SQ3ckeN2PWNqxd26W9Z2fCK1tGrrasGy4puvNFtnddqH9UJFMQYXxEuuB7B8UK+LLwSg==",
+      "dev": true
+    },
     "@types/parse5": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
@@ -4482,8 +4488,7 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parallel-transform": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/firefox-webext-browser": "^78.0.1",
     "@types/jsdom": "^16.2.4",
     "@types/mocha": "^8.0.3",
+    "@types/pako": "^1.0.1",
     "@types/uuid": "^8.3.0",
     "chai": "^4.2.0",
     "clean-webpack-plugin": "^3.0.0",
@@ -38,6 +39,7 @@
   },
   "dependencies": {
     "base64-js": "1.3.1",
+    "pako": "^1.0.11",
     "uuid": "8.3.0",
     "webextension-polyfill": "0.6.0"
   }

--- a/src/background/SensorEventAPI.ts
+++ b/src/background/SensorEventAPI.ts
@@ -20,6 +20,7 @@
 import { ManagedStorage } from './storage/ManagedStorage'
 import { Installer } from './install/Installer'
 import { Event } from '../common/events/Event'
+import { gzip } from 'pako'
 
 export class SensorEventAPI {
 
@@ -46,7 +47,7 @@ export class SensorEventAPI {
         // This will throw if things go bad
         const response = await fetch(eventUrl, {
             method: 'POST',
-            body: JSON.stringify(events),
+            body: gzip(JSON.stringify(events), { to: undefined }),
             headers: headers
         })
 
@@ -65,6 +66,7 @@ export class SensorEventAPI {
         const token = await this.installer.getAuthorizationToken()
         return new Headers({
             'Content-Type': 'application/json',
+            'Content-Encoding': 'gzip',
             'Authorization': `Bearer ${token}`
         })
     }

--- a/src/background/SensorEventAPI.ts
+++ b/src/background/SensorEventAPI.ts
@@ -47,7 +47,7 @@ export class SensorEventAPI {
         // This will throw if things go bad
         const response = await fetch(eventUrl, {
             method: 'POST',
-            body: gzip(JSON.stringify(events), { to: undefined }),
+            body: gzip(JSON.stringify(events)),
             headers: headers
         })
 


### PR DESCRIPTION
Only event submissions are compressed because it is an authenticated api
Therefore auth can be performed before decompressing
This reduces risk of zip bomb
Pako used as dependency for this